### PR TITLE
FSM Multithreading Fix

### DIFF
--- a/src/kernel/fsm.c
+++ b/src/kernel/fsm.c
@@ -23,32 +23,16 @@
 **                            STRUCTURE DECLARATIONS
 *******************************************************************************/
 /**
- * @brief   FSM Event Enumerations
- *
- * @details Enumerations for types of FSM Transitions.
- *
- * eFSMTransitionInternalEvent    internal state transition.
- * eFSMTransitionExternalEvent    external state transition.
- */
-typedef enum
-{
-    eFSMTransitionInternalEvent,
-    eFSMTransitionExternalEvent,
-} eFSMTransistion_t;
-
-/**
  * @brief   FSM Task Event Structure
  *
  * @details Structure for transition events submitted to FSM task.
  *
- * eTransitionType      the type of transition.
  * new_state            the new state transitioning to.
  * fsm                  pointer to fsm that should transition.
  * data                 pointer to event specific data.
  */
 typedef struct
 {
-    eFSMTransistion_t eTransitionType;
     uint8_t new_state;
     fsm_t *fsm;
     void *data;
@@ -86,33 +70,6 @@ static void prvFSMTask(void *pvParameters);
  * @return      void.
  */
 static void fsm_update(fsm_t *fsm);
-
-/**
- * @brief   Private Handle Internal Event
- *
- * @details Internal function for handling an internal FSM event.
- *
- * @param[in]   fsm         pointer to FSM instance.
- * @param[in]   new_state   new state that FSM should move to.
- * @param[in]   data        pointer to function specific data.
- *
- * @return      void.
- */
-static void private_handle_internal_event(fsm_t *fsm, uint8_t new_state, void *data);
-
-/**
- * @brief   Private Handle External Event
- *
- * @details Internal function for handling an external FSM event.
- *
- * @param[in]   fsm         pointer to FSM instance.
- * @param[in]   new_state   new state that FSM should move to.
- * @param[in]   data        pointer to function specific data.
- *
- * @return      void.
- */
-static void private_handle_external_event(fsm_t *fsm, uint8_t new_state, void *data);
-
 
 /*******************************************************************************
 **                              IMPLEMENTATIONS
@@ -168,42 +125,21 @@ void fsm_register_state_change_callback(fsm_t *fsm, const state_change_cb_t cb, 
 
 void fsm_handle_internal_event(fsm_t *fsm, uint8_t new_state, void *data)
 {
-    FSMTaskEvent_t xEvent;
-    // Don't submit into queue if already running as FSM Task
-    if (xTaskGetCurrentTaskHandle() == xFSMTaskHandle)
-    {
-        private_handle_internal_event(fsm, new_state, data);
-        return;
-    }
-
-    xEvent.eTransitionType = eFSMTransitionInternalEvent;
-    xEvent.fsm = fsm;
-    xEvent.new_state = new_state;
-    xEvent.data = data;
-    xQueueSendToBack(xFSMEventQueue, &xEvent, portMAX_DELAY);
+    fsm->data = data;
+    fsm->next_state = new_state;
+    fsm->event_handled = 0;
 }
 
 void fsm_handle_external_event(fsm_t *fsm, uint8_t new_state, void *data)
 {
-    FSMTaskEvent_t xEvent;
-    // Don't submit into queue if already running as FSM Task
-    if (xTaskGetCurrentTaskHandle() == xFSMTaskHandle)
-    {
-        private_handle_external_event(fsm, new_state, data);
-        return;
-    }
-    xEvent.eTransitionType = eFSMTransitionExternalEvent;
-    xEvent.fsm = fsm;
-    xEvent.new_state = new_state;
-    xEvent.data = data;
-    xQueueSendToBack(xFSMEventQueue, &xEvent, portMAX_DELAY);
+    fsm_handle_internal_event(fsm, new_state, data);
+    fsm_update(fsm);
 }
 
 void fsm_handle_interrupt_event(fsm_t *fsm, uint8_t new_state, void *data)
 {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     FSMTaskEvent_t xEvent;
-    xEvent.eTransitionType = eFSMTransitionExternalEvent;
     xEvent.fsm = fsm;
     xEvent.new_state = new_state;
     xEvent.data = data;
@@ -247,19 +183,6 @@ static void fsm_update(fsm_t *fsm)
     }
 }
 
-static void private_handle_internal_event(fsm_t *fsm, uint8_t new_state, void *data)
-{
-    fsm->data = data;
-    fsm->next_state = new_state;
-    fsm->event_handled = 0;
-}
-
-static void private_handle_external_event(fsm_t *fsm, uint8_t new_state, void *data)
-{
-    private_handle_internal_event(fsm, new_state, data);
-    fsm_update(fsm);
-}
-
 static void prvFSMTask(void *pvParameters)
 {
     FSMTaskEvent_t xEvent;
@@ -268,15 +191,6 @@ static void prvFSMTask(void *pvParameters)
     {
         // Block indefinitely
         xQueueReceive(xFSMEventQueue, &xEvent, portMAX_DELAY);
-
-        switch(xEvent.eTransitionType)
-        {
-            case eFSMTransitionExternalEvent:
-                private_handle_external_event(xEvent.fsm, xEvent.new_state, xEvent.data);
-                break;
-            case eFSMTransitionInternalEvent:
-                private_handle_internal_event(xEvent.fsm, xEvent.new_state, xEvent.data);
-                break;
-        }
+        fsm_handle_external_event(xEvent.fsm, xEvent.new_state, xEvent.data);
     }
 }


### PR DESCRIPTION
Fixes:
  - Fixed issue where using a dedicated FSM thread for all FSM
    event could result in two FSMs deadlocking one another. FSM
    was updated to only run IRQ based FSM events in a dedicated
    thread.

Features:
  - None