### PR TITLE
WH440 Memory Map Fix

### DIFF
--- a/bsp/wavious-wh440/board/memory_map.h
+++ b/bsp/wavious-wh440/board/memory_map.h
@@ -12,7 +12,6 @@
 #define MEMORY_MAP_UART                     (0x54000000)
 #define MEMORY_MAP_ONCHIPSRAM               (0x60000000)
 #define MEMORY_MAP_QSPI_FLASH_DIRECT_MEM    (0x70000000)
-#define MEMORY_MAP_WTM_CSR                  (0x80000000)
 #define MEMORY_MAP_QSPI_FLASH               (0x90000000)
 #define MEMORY_MAP_HBS                      (0xA0000000)
 #define MEMORY_MAP_HBS_RPLL_CPUSS           (MEMORY_MAP_HBS + 0x100)


### PR DESCRIPTION
Fixes:
  - Removed memory map entry that belong to WTM and not WH440

Features:
  - None