### PR TITLE
RTOS Feature Cleanup

### DIFF
--- a/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
+++ b/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
@@ -105,8 +105,8 @@
 
 /* Software timer definitions. SwitchC */
 #define configUSE_TIMERS                1
-#define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 1 )
-#define configTIMER_QUEUE_LENGTH        4
+#define configTIMER_TASK_PRIORITY       1
+#define configTIMER_QUEUE_LENGTH        8
 /*
  * configTIMER_TASK_STACK_DEPTH must be a value greater than 80 + the sizeof the register saved.
  * The size of the register is differrent from a core to another, e.g. on RiscV

--- a/include/kernel/completion.h
+++ b/include/kernel/completion.h
@@ -14,12 +14,14 @@
  * @brief   Completion Structure
  *
  * @details Completion structure that can be used to synchronize a task with the
- *          completion of an event. NOTE: Only one task can be sychronized at a
- *          given time.
+ *          completion of an event.
  *
- * @ucDone      done flag to indicate that event occurred.
- * @xTaskHandle pointer to the current task that is waiting on the completion.
- * @lock        spinlock for locking completion state.
+ * @note    Similar to task notifications provided by FreeRTOS but this is
+ *          task safe so state is shared amongst tasks. That means different
+ *          tasks can use the same completion state.
+ *
+ * ucDone       done flag to indicate that event occurred.
+ * xTaskHandle  pointer to the current task that is waiting on the completion.
  */
 typedef struct completion
 {

--- a/include/kernel/notification.h
+++ b/include/kernel/notification.h
@@ -17,7 +17,7 @@
  *
  * @details Represents a specific notification value.
  */
-typedef BaseType_t Notification_t;
+typedef UBaseType_t Notification_t;
 
 /** @brief  Notification Handler */
 typedef void (*NotificationHandler_t)(Notification_t notification, void *args);

--- a/src/kernel/messenger.c
+++ b/src/kernel/messenger.c
@@ -20,7 +20,7 @@
     #define CONFIG_MESSAGE_QUEUE_LENGTH         (4)
 #endif /* CONFIG_NOTIFICATION_QUEUE_LENGTH */
 #ifndef CONFIG_MESSENGER_TASK_PRIORITY
-    #define CONFIG_MESSENGER_TASK_PRIORITY      (configMAX_PRIORITIES - 2)
+    #define CONFIG_MESSENGER_TASK_PRIORITY      (configMAX_PRIORITIES - 4)
 #endif /* CONFIG_NOTIFICATION_TASK_PRIORITY */
 
 #define CONFIG_EVENT_QUEUE_LENGTH               (CONFIG_MESSAGE_QUEUE_LENGTH >> 1)
@@ -216,7 +216,6 @@ BaseType_t xSendMessage(UBaseType_t uAddress, Message_t *pxMessage)
     // Send
     return pxInterface->intf.xSend(pxInterface->intf.dev, (void *) pxMessage, sizeof(Message_t));
 }
-
 
 BaseType_t xReceiveMessage(UBaseType_t uAddress, Message_t *pxMessage)
 {


### PR DESCRIPTION
Fixes:
  - Fixed documentation format for completion structure
  - Fixed issue where Notification_t value was signed value
  - Fixed issue where bad formatting was used in taskENTER_CTRITICAL()
    block
  - Removed uncessary code from fsm_handle_internal_event since function
    should always run in FSM Task context
  - Made Timer Daemon Task the lowest priority for wav-mcu board as it
    would starve critical operations. Typically, FSM Task would
    immediately context switch to Timer Task so timer operation could
    be serviced. This would cause delays in prep / switch time.

Features:
  - FSM, Messenger and Notification Task priorities adjusted to minimize
    context switches based on how these features are used
  - Notification Task communication simplified for performance