### PR TITLE
Freedom Metal Code Reduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,6 @@ include(${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/CMakeLists.txt)
 # Create Metal Library
 FILE(
     GLOB_RECURSE
-    METAL_SRC
-    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.c
-    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.S
-)
-
-FILE(
-    GLOB_RECURSE
     GLOSS_SRC
     ${WAV_RTOS_TOP_LEVEL}/freedom-metal/gloss/*.c
     ${WAV_RTOS_TOP_LEVEL}/freedom-metal/gloss/*.S
@@ -54,7 +47,7 @@ FILE(
 
 set(
     METAL_LIB_SRC
-    ${METAL_SRC}
+    ${BSP_METAL_SOURCES}
     ${GLOSS_SRC}
 )
 
@@ -72,32 +65,23 @@ target_compile_options(
     -Wno-array-bounds
 )
 
+target_link_libraries(
+    metal
+    "-Wl,--start-group"
+    c
+    gcc
+    m
+    "-Wl,--end-group"
+)
+
 #-------------------------------#
 #     FreeRTOS Library          #
 #-------------------------------#
 # Create FreeRTOS Library
-FILE(
-    GLOB
-    FREERTOS_SRC
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/*.c
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.c
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.S
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/MemMang/heap_${RTOS_HEAP_ALLOC_SCHEME}.c
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/Bridge_Freedom-metal_FreeRTOS.c
-)
-
 add_library(
     freertos
     STATIC
-    ${FREERTOS_SRC}
-)
-
-target_include_directories(
-    freertos
-    PUBLIC
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/include
-    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos
+    ${BSP_FREERTOS_SOURCES}
 )
 
 target_compile_options(
@@ -106,7 +90,11 @@ target_compile_options(
     ${BSP_FREERTOS_COMPILE_OPTIONS}
 )
 
-target_link_libraries(freertos metal bsp_freertos)
+target_link_libraries(
+    freertos
+    metal
+    bsp_freertos
+)
 
 #-------------------------------#
 #      Everything else          #

--- a/app/freertos-sample/CMakeLists.txt
+++ b/app/freertos-sample/CMakeLists.txt
@@ -32,14 +32,7 @@ target_compile_definitions(
 )
 
 target_link_libraries(${PROJECT_NAME}
-    "-Wl,--start-group"
-    c
-    gcc
-    m
-    metal
     kernel
-    freertos
-    "-Wl,--end-group"
 )
 
 target_link_options(

--- a/bsp/wavious-mcu/CMakeLists.txt
+++ b/bsp/wavious-mcu/CMakeLists.txt
@@ -6,6 +6,31 @@ set(CONFIG_WAV_MCU_IRQ_EDGE_CFG 0x1FFFFBFC)
 # wavious-mcu is type client, set host to 0x0
 set(CONFIG_WAV_MESSENGER_INTF_HOST 0x0)
 
+FILE(
+    GLOB_RECURSE
+    BSP_METAL_SOURCES
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/metal/riscv_cpu_min.c
+    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.c
+    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.S
+)
+
+list(
+    REMOVE_ITEM
+    BSP_METAL_SOURCES
+    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/drivers/riscv_cpu.c
+)
+
+FILE(
+    GLOB
+    BSP_FREERTOS_SOURCES
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/*.c
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.c
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.S
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/MemMang/heap_${RTOS_HEAP_ALLOC_SCHEME}.c
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/Bridge_Freedom-metal_FreeRTOS.c
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/vector.S
+)
+
 #-------------------------------#
 #     FreeRTOS Library          #
 #-------------------------------#
@@ -14,11 +39,12 @@ add_library(
     INTERFACE
 )
 
-target_sources(
+target_include_directories(
     bsp_freertos
     INTERFACE
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/vector.S
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/boot.S
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/include
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos
 )
 
 target_compile_options(

--- a/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
+++ b/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
@@ -73,7 +73,7 @@ your application. */
 #define INCLUDE_vTaskDelete                     1
 #define INCLUDE_vTaskSuspend                    0
 #define INCLUDE_xResumeFromISR                  0
-#define INCLUDE_vTaskDelayUntil                 0
+#define INCLUDE_vTaskDelayUntil                 1
 #define INCLUDE_vTaskDelay                      1
 #define INCLUDE_xTaskGetSchedulerState          0
 #define INCLUDE_xTaskGetCurrentTaskHandle       1

--- a/bsp/wavious-mcu/freertos/boot.S
+++ b/bsp/wavious-mcu/freertos/boot.S
@@ -1,4 +1,0 @@
-.section .boot
-.option norvc
-__jump_to_start:
-    j __start

--- a/bsp/wavious-mcu/freertos/freertos_risc_v_chip_specific_extensions.h
+++ b/bsp/wavious-mcu/freertos/freertos_risc_v_chip_specific_extensions.h
@@ -58,7 +58,6 @@
 #define portasmADDITIONAL_CONTEXT_SIZE 0 /* Must be even number on 32-bit cores. */
 
 #define portasmHANDLE_INTERRUPT     FreedomMetal_InterruptHandler
-#define portasmHANDLE_EXCEPTION     FreedomMetal_ExceptionHandler
 
 .macro portasmSAVE_ADDITIONAL_REGISTERS
         /* No additional registers to save, so this macro does nothing. */

--- a/bsp/wavious-mcu/freertos/vector.S
+++ b/bsp/wavious-mcu/freertos/vector.S
@@ -176,3 +176,7 @@ IRQ_LC14:
         j freertos_risc_v_trap_handler
 IRQ_LC15:
         j freertos_risc_v_trap_handler
+
+.section .boot
+__jump_to_start:
+    j __start

--- a/bsp/wavious-mcu/metal/drivers/riscv_cpu_min.h
+++ b/bsp/wavious-mcu/metal/drivers/riscv_cpu_min.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 Wavious LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef METAL__DRIVERS__RISCV_CPU_MIN_H
+#define METAL__DRIVERS__RISCV_CPU_MIN_H
+#include <metal/drivers/riscv_cpu.h>
+
+/* CPU interrupt controller */
+struct __metal_driver_vtable_riscv_cpu_min_intc {
+    struct metal_interrupt_vtable controller_vtable;
+};
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_cpu_min_intc)
+
+struct __metal_driver_riscv_cpu_min_intc {
+    struct metal_interrupt controller;
+    int init_done;
+    __metal_interrupt_data metal_int_table[METAL_MAX_MI];
+};
+
+struct __metal_driver_vtable_cpu_min {
+    struct metal_cpu_vtable cpu_vtable;
+};
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_cpu_min)
+
+struct __metal_driver_cpu_min {
+    struct metal_cpu cpu;
+};
+
+#endif /* METAL__DRIVERS__RISCV_CPU_MIN_H */

--- a/bsp/wavious-mcu/metal/machine.h
+++ b/bsp/wavious-mcu/metal/machine.h
@@ -69,7 +69,7 @@
 #include <metal/drivers/fixed-clock.h>
 #include <metal/memory.h>
 #include <metal/drivers/riscv_clint0.h>
-#include <metal/drivers/riscv_cpu.h>
+#include <metal/drivers/riscv_cpu_min.h>
 #include <metal/pmp.h>
 
 /* From refclk */
@@ -83,9 +83,9 @@ extern struct metal_memory __metal_dt_mem_itim_10000;
 extern struct __metal_driver_riscv_clint0 __metal_dt_clint_8000;
 
 /* From cpu@0 */
-extern struct __metal_driver_cpu __metal_dt_cpu_0;
+extern struct __metal_driver_cpu_min __metal_dt_cpu_0;
 
-extern struct __metal_driver_riscv_cpu_intc __metal_dt_cpu_0_interrupt_controller;
+extern struct __metal_driver_riscv_cpu_min_intc __metal_dt_cpu_0_interrupt_controller;
 
 extern struct metal_pmp __metal_dt_pmp;
 
@@ -300,7 +300,7 @@ struct metal_memory *__metal_memory_table[] = {
 #define __METAL_DT_MAX_HARTS 1
 
 __asm__ (".weak __metal_cpu_table");
-struct __metal_driver_cpu *__metal_cpu_table[] = {
+struct __metal_driver_cpu_min *__metal_cpu_table[] = {
                     &__metal_dt_cpu_0};
 
 #define __METAL_DT_PMP_HANDLE (&__metal_dt_pmp)

--- a/bsp/wavious-mcu/metal/machine/inline.h
+++ b/bsp/wavious-mcu/metal/machine/inline.h
@@ -137,14 +137,13 @@ struct __metal_driver_riscv_clint0 __metal_dt_clint_8000 = {
 };
 
 /* From cpu@0 */
-struct __metal_driver_cpu __metal_dt_cpu_0 = {
-    .cpu.vtable = &__metal_driver_vtable_cpu.cpu_vtable,
-    .hpm_count = 0,
+struct __metal_driver_cpu_min __metal_dt_cpu_0 = {
+    .cpu.vtable = &__metal_driver_vtable_cpu_min.cpu_vtable,
 };
 
 /* From interrupt_controller */
-struct __metal_driver_riscv_cpu_intc __metal_dt_cpu_0_interrupt_controller = {
-    .controller.vtable = &__metal_driver_vtable_riscv_cpu_intc.controller_vtable,
+struct __metal_driver_riscv_cpu_min_intc __metal_dt_cpu_0_interrupt_controller = {
+    .controller.vtable = &__metal_driver_vtable_riscv_cpu_min_intc.controller_vtable,
     .init_done = 0,
 };
 

--- a/bsp/wavious-mcu/metal/riscv_cpu_min.c
+++ b/bsp/wavious-mcu/metal/riscv_cpu_min.c
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2021 Wavious LLC.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <metal/machine.h>
+#include <metal/drivers/riscv_cpu_min.h>
+
+/*******************************************************************************
+**                   INTERRUPT CONTROLLER VTABLE
+*******************************************************************************/
+static void __metal_driver_riscv_cpu_controller_interrupt_init(struct metal_interrupt *controller)
+{
+    struct __metal_driver_riscv_cpu_min_intc *intc = (void *)(controller);
+    if (!intc->init_done)
+    {
+        // Clear out table
+        for (uint8_t i = 0; i < METAL_MAX_MI; i++)
+        {
+            intc->metal_int_table[i].handler = NULL;
+            intc->metal_int_table[i].sub_int = NULL;
+            intc->metal_int_table[i].exint_data = NULL;
+        }
+    }
+    intc->init_done = 1;
+}
+
+static int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrupt *controller,
+                                                                  int id,
+                                                                  metal_interrupt_handler_t isr,
+                                                                  void *priv)
+{
+    struct __metal_driver_riscv_cpu_min_intc *intc = (void *)(controller);
+
+    if (id >= METAL_MAX_MI)
+    {
+        return -11;
+    }
+
+    intc->metal_int_table[id].handler = isr;
+    intc->metal_int_table[id].exint_data = priv;
+    return 0;
+}
+
+static int __metal_driver_riscv_cpu_controller_interrupt_enable(struct metal_interrupt *controller,
+                                                                int id)
+{
+    uint32_t mask;
+    if (id >= METAL_MAX_MI)
+    {
+        return -1;
+    }
+
+    mask = 1 << id;
+    __asm__ volatile("csrs mie, %0" : : "r" (mask));
+    return 0;
+}
+
+static int __metal_driver_riscv_cpu_controller_interrupt_disable(struct metal_interrupt *controller,
+                                                                 int id)
+{
+    uint32_t mask;
+    if (id >= METAL_MAX_MI)
+    {
+        return -1;
+    }
+
+    mask = 1 << id;
+    __asm__ volatile("csrc mie, %0" : : "r" (mask));
+    return 0;
+}
+
+static metal_vector_mode __metal_driver_riscv_cpu_controller_get_vector_mode(struct metal_interrupt *controller)
+{
+    uintptr_t val;
+    __asm__ volatile("csrr %0, mtvec" : "=r"(val));
+    val &= 0x1;
+
+    if (val == METAL_MTVEC_VECTORED)
+    {
+        return METAL_VECTOR_MODE;
+    }
+
+    return METAL_DIRECT_MODE;
+}
+
+static int __metal_driver_riscv_cpu_controller_set_vector_mode(struct metal_interrupt *controller,
+                                                               metal_vector_mode mode)
+{
+    // Not supported
+    return -1;
+}
+
+static int __metal_driver_riscv_cpu_controller_command_request(struct metal_interrupt *controller,
+                                                               int cmd,
+                                                               void *data)
+{
+    // Not supported
+    return 0;
+}
+
+/*******************************************************************************
+**                          CPU VTABLE
+*******************************************************************************/
+static struct metal_interrupt * __metal_driver_cpu_controller_interrupt(struct metal_cpu *cpu)
+{
+    return __metal_driver_cpu_interrupt_controller(cpu);
+}
+
+static int __metal_driver_cpu_get_timer_interrupt_id(struct metal_cpu *cpu)
+{
+    return METAL_INTERRUPT_ID_TMR;
+}
+
+static int __metal_driver_cpu_get_sw_interrupt_id(struct metal_cpu *cpu)
+{
+    return METAL_INTERRUPT_ID_SW;
+}
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_cpu_min_intc) = {
+    .controller_vtable.interrupt_init =
+        __metal_driver_riscv_cpu_controller_interrupt_init,
+    .controller_vtable.interrupt_register =
+        __metal_driver_riscv_cpu_controller_interrupt_register,
+    .controller_vtable.interrupt_enable =
+        __metal_driver_riscv_cpu_controller_interrupt_enable,
+    .controller_vtable.interrupt_disable =
+        __metal_driver_riscv_cpu_controller_interrupt_disable,
+    .controller_vtable.interrupt_get_vector_mode =
+        __metal_driver_riscv_cpu_controller_get_vector_mode,
+    .controller_vtable.interrupt_set_vector_mode =
+        __metal_driver_riscv_cpu_controller_set_vector_mode,
+    .controller_vtable.command_request =
+        __metal_driver_riscv_cpu_controller_command_request,
+};
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_cpu_min) = {
+    .cpu_vtable.mcycle_get = NULL,
+    .cpu_vtable.timebase_get = NULL,
+    .cpu_vtable.mtime_get = NULL,
+    .cpu_vtable.mtimecmp_set = NULL,
+    .cpu_vtable.tmr_controller_interrupt = NULL,
+    .cpu_vtable.get_tmr_interrupt_id = __metal_driver_cpu_get_timer_interrupt_id,
+    .cpu_vtable.sw_controller_interrupt = NULL,
+    .cpu_vtable.get_sw_interrupt_id = __metal_driver_cpu_get_sw_interrupt_id,
+    .cpu_vtable.set_sw_ipi = NULL,
+    .cpu_vtable.clear_sw_ipi = NULL,
+    .cpu_vtable.get_msip = NULL,
+    .cpu_vtable.controller_interrupt = __metal_driver_cpu_controller_interrupt,
+    .cpu_vtable.exception_register = NULL,
+    .cpu_vtable.get_ilen = NULL,
+    .cpu_vtable.get_epc = NULL,
+    .cpu_vtable.set_epc = NULL,
+    .cpu_vtable.get_buserror = NULL,
+};

--- a/bsp/wavious-wh440/CMakeLists.txt
+++ b/bsp/wavious-wh440/CMakeLists.txt
@@ -2,6 +2,25 @@
 # wavious-wh440 is type host, set host to 0x1
 set(CONFIG_WAV_MESSENGER_INTF_HOST 0x1)
 
+FILE(
+    GLOB_RECURSE
+    BSP_METAL_SOURCES
+    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.c
+    ${WAV_RTOS_TOP_LEVEL}/freedom-metal/src/*.S
+)
+
+FILE(
+    GLOB
+    BSP_FREERTOS_SOURCES
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/*.c
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.c
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/*.S
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/MemMang/heap_${RTOS_HEAP_ALLOC_SCHEME}.c
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/Bridge_Freedom-metal_FreeRTOS.c
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/printf.c
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/vector.S
+)
+
 #-------------------------------#
 #     FreeRTOS Library          #
 #-------------------------------#
@@ -10,11 +29,12 @@ add_library(
     INTERFACE
 )
 
-target_sources(
+target_include_directories(
     bsp_freertos
     INTERFACE
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/vector.S
-    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos/printf.c
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/include
+    ${WAV_RTOS_TOP_LEVEL}/FreeRTOS-Kernel/portable/GCC/RISC-V/
+    ${WAV_RTOS_TOP_LEVEL}/bsp/${CONFIG_TARGET_BOARD}/freertos
 )
 
 target_compile_options(

--- a/bsp/wavious-wh440/freertos/freertos_risc_v_chip_specific_extensions.h
+++ b/bsp/wavious-wh440/freertos/freertos_risc_v_chip_specific_extensions.h
@@ -58,7 +58,6 @@
 #define portasmADDITIONAL_CONTEXT_SIZE 0 /* Must be even number on 32-bit cores. */
 
 #define portasmHANDLE_INTERRUPT     FreedomMetal_InterruptHandler
-#define portasmHANDLE_EXCEPTION     FreedomMetal_ExceptionHandler
 
 .macro portasmSAVE_ADDITIONAL_REGISTERS
         /* No additional registers to save, so this macro does nothing. */

--- a/bsp/wavious-wh440/metal.freertos.lds
+++ b/bsp/wavious-wh440/metal.freertos.lds
@@ -92,10 +92,10 @@ SECTIONS
     .init : {
         KEEP (*(.image_hdr))
         PROVIDE(g_note_build_id = .);
-        KEEP(*(.note.gnu.build-id)
+        KEEP(*(.note.gnu.build-id))
         /* The _enter symbol is placed in the .text.metal.init.enter section
          * and must be placed at the beginning of the program */
-        PROVIDE(__start = .)
+        PROVIDE(__start = .);
         KEEP (*(.text.metal.init.enter))
         KEEP (*(.text.metal.init.*))
         KEEP (*(SORT_NONE(.init)))


### PR DESCRIPTION
Fixes:
  - Fixed issue with Wavious-WH440 board linker script

Features:
  - Added riscv_cpu_min implementation for Freedom Metal to
    be used with wavious-mcu board. Includes minimal amount
    of code required for use with FreeRTOS
  - CMake changes to support riscv_cpu_min implementation
  - Dead code removal
  - Metal library now linked correctly (#32)