### PR TITLE
WMCU IRQ Configuration Fix

### DIFF
--- a/bsp/wavious-mcu/CMakeLists.txt
+++ b/bsp/wavious-mcu/CMakeLists.txt
@@ -1,6 +1,10 @@
 # MCU Interrupt Configuration
-set(CONFIG_WAV_MCU_IRQ_SYNC_CFG 0x00000403)
-set(CONFIG_WAV_MCU_IRQ_EDGE_CFG 0x1FFFFBFC)
+if (NOT DEFINED ${CONFIG_WAV_MCU_IRQ_SYNC_CFG})
+    set(CONFIG_WAV_MCU_IRQ_SYNC_CFG 0x00000000)
+endif()
+if (NOT DEFINED ${CONFIG_WAV_MCU_IRQ_EDGE_CFG})
+    set(CONFIG_WAV_MCU_IRQ_EDGE_CFG 0x00000000)
+endif()
 
 # Set Messaging Interface to MCU Type
 # wavious-mcu is type client, set host to 0x0


### PR DESCRIPTION
Fixes:
  - Fixed issue where WMCU IRQ configuration was setup for
    WDDR100's configuration. This will be an issue when using
    wavious-mcu bsp for other WMCU based projects (#48)