### PR TITLE
Bug Fixes

### DIFF
--- a/app/freertos-sample/main.c
+++ b/app/freertos-sample/main.c
@@ -63,7 +63,7 @@ int main( void )
 
     // Create shutdown timer
     xTimer = xTimerCreate("Shtudown",
-                          pdMS_TO_TICKS(5),
+                          pdMS_TO_TICKS(2),
                           pdFALSE,
                           NULL,
                           vShutdown);
@@ -180,6 +180,19 @@ void vApplicationTickHook( void )
 /*-----------------------------------------------------------*/
 void vAssertCalled( const char * const pcFileName, unsigned long ulLine )
 {
+    const char *pcString = pcFileName;
+    uint32_t ulFileNameLen = strlen(pcFileName);
+    char cFileName[7] = {'\0'};
+
+    // Extract filename
+    memcpy(&cFileName[0], &pcString[ulFileNameLen - 6], 6);
+
+    // Ignore assertions from port.c
+    if (!strcmp(&cFileName[0], "port.c"))
+    {
+        return;
+    }
+
     configPRINTF(("ERROR: Aserrtion in %s on line %lu.\n", pcFileName, ulLine));
     taskDISABLE_INTERRUPTS();
     _exit(1);

--- a/bsp/wavious-mcu/CMakeLists.txt
+++ b/bsp/wavious-mcu/CMakeLists.txt
@@ -85,7 +85,7 @@ macro(bsp_post_build TARGET)
     )
     add_custom_command(TARGET ${TARGET}
         POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} ${TARGET} -O binary ${TARGET}_itcm.bin -j .text -j .init
+        COMMAND ${CMAKE_OBJCOPY} ${TARGET} -O binary ${TARGET}_itcm.bin -j .text -j .init -j .ctors
         COMMAND ${CMAKE_OBJCOPY} ${TARGET} -O binary ${TARGET}_dtcm.bin -j .preinit_array -j .init_array -j .fini_array -j .rodata -j .data -j .tdata -j .tbss -j .bss
         WORKING_DIRECTORY ${WORKING_DIRECTORY}
     )

--- a/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
+++ b/bsp/wavious-mcu/freertos/FreeRTOSConfig.h
@@ -57,7 +57,7 @@ your application. */
 
 /* Software timer related definitions. */
 #define configUSE_TIMERS                        1
-#define configTIMER_TASK_PRIORITY               1
+#define configTIMER_TASK_PRIORITY               (configMAX_PRIORITIES - 1)
 #define configTIMER_QUEUE_LENGTH                8
 #define configTIMER_TASK_STACK_DEPTH            configMINIMAL_STACK_SIZE
 

--- a/bsp/wavious-wh440/freertos/FreeRTOSConfig.h
+++ b/bsp/wavious-wh440/freertos/FreeRTOSConfig.h
@@ -57,7 +57,7 @@ your application. */
 
 /* Software timer related definitions. */
 #define configUSE_TIMERS                        1
-#define configTIMER_TASK_PRIORITY               1
+#define configTIMER_TASK_PRIORITY               (configMAX_PRIORITIES - 1)
 #define configTIMER_QUEUE_LENGTH                8
 #define configTIMER_TASK_STACK_DEPTH            configMINIMAL_STACK_SIZE
 

--- a/src/hal/riscv/init.c
+++ b/src/hal/riscv/init.c
@@ -24,19 +24,6 @@ static uint64_t _prv_timer_rate   = 0UL;
 static uint64_t ullNextTime       = 0ULL;
 static volatile uint64_t *pullMachineTimerCompareRegister;
 
-/**
- * Override weak declarations as not needed for our application.
- */
-void metal_init_run(void)
-{
-    // Intentionally empty
-}
-
-void metal_fini_run(void)
-{
-    // Intentionally empty
-}
-
 void hal_timer_init(uint64_t timer_rate)
 {
     uint32_t ulCurrentTimeHigh, ulCurrentTimeLow;


### PR DESCRIPTION
Fixes:
  - Fixed issue where .ctors section wasn't exported
  - Fixed issue where metal library init functions
    weren't called. These weren't used before but are
    now required since WMCU now has a "uart".
  - vAssertCalled now ignores any exceptions from port.c.
    This is a known issue for the wavious-mcu board.
  - Fixed issue where timers couldn't preempt other threads
    because timer priority was too low. Timers in general
    need to be revisited.

Features:
  - None