### PR TITLE
wav-build integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,93 @@
+---
+Language:        Cpp
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AllowShortLambdasOnASingleLine: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeElse:      true
+  IndentBraces:    true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ColumnLimit:     120
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+IncludeBlocks:   Preserve
+#TODO: Revisit this for include grouping
+# IncludeCategories:
+#   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+#     Priority:        2
+#     SortPriority:    0
+#   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+#     Priority:        3
+#     SortPriority:    0
+#   - Regex:           '.*'
+#     Priority:        1
+#     SortPriority:    0
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+PointerAlignment: Right
+ReferenceAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 Wavious RTOS Base Software project. This project contains all code
 that runs on the various wavious cores utilizing FreeRTOS
 
+## pre-commit
+This project uses pre-commit to ensure that all source files are properly
+formatted. To install pre-commit, ensure that you have a version of python
+installed as well as pip. With pip installed run:
+`pip install pre-commit`
+
+Once pre-commit is installed via python3, then pre-commit needs to be installed
+for this project. Run the following to install pre-commit:
+`pre-commit install -c wav-build/.pre-commit-config.yaml`
+
+pre-commit will be executed any time `git commit` command is executed.
+
+Refer to [pre-commit](https://pre-commit.com/) for more details.
+
 ## Build Configuration
 When the project is first clone, the project needs to be configured using the
 following command:

--- a/app/freertos-sample/main.c
+++ b/app/freertos-sample/main.c
@@ -20,6 +20,9 @@
 #include <osal/printf.h>
 
 /*-----------------------------------------------------------*/
+/* Don't include image header for POSIX based builds */
+#ifndef _POSIX_VERSION
+extern uintptr_t __start;
 img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .image_magic = IMAGE_MAGIC,
     .image_hdr_version = IMAGE_VERSION_CURRENT,
@@ -27,6 +30,8 @@ img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .version_major = 1,
     .version_minor = 0,
     .version_patch = 0,
+    .vector_size = VECTOR_SIZE,
+    .vector_addr = (uintptr_t) &__start,
     .device_id = IMAGE_DEVICE_ID_HOST,
     .git_dirty = GIT_DIRTY,
     .git_ahead = GIT_AHEAD,
@@ -35,6 +40,7 @@ img_hdr_t image_hdr __attribute__((section(".image_hdr"))) = {
     .crc = 0,
     .data_size = 0,
 };
+#endif /* !_POSIX_VERSION */
 
 /*-----------------------------------------------------------*/
 /*


### PR DESCRIPTION
Fixes:
  - Fixes Image header for 64-bit processors (#31)

Features:
  - precommit integration
  - added clang formatting rules