### PR TITLE
Removed uncessary include

### DIFF
--- a/bsp/wavious-mcu/board/board.c
+++ b/bsp/wavious-mcu/board/board.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <stdint.h>
+
 #include "memory_map.h"
 
 #ifndef WAV_MCU_IRQ_SYNC_CFG

--- a/bsp/wavious-mcu/board/memory_map.h
+++ b/bsp/wavious-mcu/board/memory_map.h
@@ -6,8 +6,6 @@
 #ifndef _BOARD_MEMORY_MAP_H_
 #define _BOARD_MEMORY_MAP_H_
 
-#include <stdint.h>
-
 #include "wav_mcu_csr.h"
 
 // Common MCU registers (same for all Wavious MCUs)


### PR DESCRIPTION
Fixes:
  - Fixed an issue where including stdint in
    wmcu/board/memory_map.h could break some test apps
    that don't use the full wav-rtos-sw infrastructure
    but do require wmcu memory map

Features:
  - None